### PR TITLE
All-exclusionary pathspec patterns are not supported by older versions of Git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 UTC is used when determining release dates.
 
 ## [Unreleased](https://github.com/apcountryman/dotfiles/compare/master...develop)
+### Fixed
+- [All-exclusionary pathspec patterns are not supported by older versions of Git](https://github.com/apcountryman/dotfiles/issues/9).
 
 ## [0.1.0](https://github.com/apcountryman/dotfiles/compare/cd276ce3083f6c130eae8b134a82247847ce06ed...0.1.0) - 2019-11-16
 ### Added

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -93,7 +93,7 @@ function ensure_no_script_errors_are_present()
     message "checking for script errors ........................ "
 
     local scripts
-    mapfile -t scripts < <( git -C "$REPOSITORY" ls-files -- ':!:.vim/extensions/vim-plug' | xargs -r -d '\n' -I '{}' find "$REPOSITORY/"{} -executable ); readonly scripts
+    mapfile -t scripts < <( git -C "$REPOSITORY" ls-files -- . ':!:.vim/extensions/vim-plug' | xargs -r -d '\n' -I '{}' find "$REPOSITORY/"{} -executable ); readonly scripts
 
     if ! shellcheck "${scripts[@]}" >/dev/null 2>&1; then
         errors_found

--- a/install
+++ b/install
@@ -146,7 +146,7 @@ function main()
     MNEMONIC=$( basename "$SCRIPT" ); readonly MNEMONIC
     REPOSITORY=$( dirname "$SCRIPT" ); readonly REPOSITORY
 
-    mapfile -t SUPPORTED_DOTFILES < <( cd "$REPOSITORY" && git ls-files -- ':!:.gitmodules' | cut -d / -f 1 | sort -u | xargs -r -d '\n' -I '{}' find {} -maxdepth 0 -name '.*' ); readonly SUPPORTED_DOTFILES
+    mapfile -t SUPPORTED_DOTFILES < <( cd "$REPOSITORY" && git ls-files -- . ':!:.gitmodules' | cut -d / -f 1 | sort -u | xargs -r -d '\n' -I '{}' find {} -maxdepth 0 -name '.*' ); readonly SUPPORTED_DOTFILES
 
     local dotfiles=()
 


### PR DESCRIPTION
Resolves #9.