### PR TITLE
Git pre-commit hook script's help text synopsis section does not cover typical usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 UTC is used when determining release dates.
 
 ## [Unreleased](https://github.com/apcountryman/dotfiles/compare/master...develop)
+### Fixed
+- [Git pre-commit hook script's help text SYNOPSIS section does not cover typical usage)(https://github.com/apcountryman/dotfiles/issues/22).
 
 ## [0.2.0](https://github.com/apcountryman/dotfiles/compare/0.1.1...0.2.0) - 2019-11-19
 ### Added

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -53,6 +53,7 @@ function display_help_text()
     echo "    $MNEMONIC - Execute the dotfiles repository's Git pre-commit hook."
     echo "SYNOPSIS"
     echo "    $MNEMONIC --help"
+    echo "    $MNEMONIC"
     echo "OPTIONS"
     echo "    --help"
     echo "        Display this help text."


### PR DESCRIPTION
Resolves #22.