### PR TITLE
Update submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 # vim-plug (Vim plugin manager)
 [submodule ".vim/extensions/vim-plug"]
 	path = dotfiles/.vim/extensions/vim-plug
-	url = ../junegunn-vim-plug
+	url = ../vim-plug


### PR DESCRIPTION
Resolves #69.

The vim-plug submodule URL currently points to a "mirror"
(junegunn-vim-plug) instead of a fork (vim-plug).