### PR TITLE
Update vim plugin URLs

### DIFF
--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -18,13 +18,13 @@
 " plugins
 call plug#begin( '$HOME/.vim/extensions' )
     " color scheme
-    Plug 'apcountryman/nanotech-jellybeans.vim'
+    Plug 'apcountryman/jellybeans.vim'
 
     " text alignment
-    Plug 'apcountryman/godlygeek-tabular'
+    Plug 'apcountryman/tabular'
 
     " PlantUML syntax
-    Plug 'apcountryman/aklt-plantuml-syntax'
+    Plug 'apcountryman/plantuml-syntax'
 call plug#end()
 
 " general


### PR DESCRIPTION
Resolves #70.

vim plugin URLs currently point to "mirrors"
(apcountryman/nanotech-jellybeans.vim, apcountryman/godlygeek-tabular,
and apcountryman/aklt-plantuml-syntax) instead of forks
(apcountryman/jellybeans.vim, apcountryman/tabular, and
apcountryman/plantuml-syntax).