### PR TITLE
Standardize copyright notice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 # dotfiles
 #
-# Copyright 2020 Andrew Countryman <apcountryman@gmail.com>
+# Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+# contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 # file except in compliance with the License. You may obtain a copy of the License at

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # dotfiles
 #
-# Copyright 2019, 2020 Andrew Countryman <apcountryman@gmail.com>
+# Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+# contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 # file except in compliance with the License. You may obtain a copy of the License at

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 # dotfiles
 #
-# Copyright 2019, 2020 Andrew Countryman <apcountryman@gmail.com>
+# Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+# contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 # file except in compliance with the License. You may obtain a copy of the License at

--- a/ci/analyze
+++ b/ci/analyze
@@ -2,7 +2,8 @@
 
 # dotfiles
 #
-# Copyright 2020 Andrew Countryman <apcountryman@gmail.com>
+# Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+# contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 # file except in compliance with the License. You may obtain a copy of the License at

--- a/dotfiles/.gitconfig
+++ b/dotfiles/.gitconfig
@@ -1,6 +1,7 @@
 # dotfiles
 #
-# Copyright 2019, 2020 Andrew Countryman <apcountryman@gmail.com>
+# Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+# contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 # file except in compliance with the License. You may obtain a copy of the License at

--- a/dotfiles/.gitignore
+++ b/dotfiles/.gitignore
@@ -1,6 +1,7 @@
 # dotfiles
 #
-# Copyright 2019, 2020 Andrew Countryman <apcountryman@gmail.com>
+# Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+# contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 # file except in compliance with the License. You may obtain a copy of the License at

--- a/dotfiles/.vim/filetype.vim
+++ b/dotfiles/.vim/filetype.vim
@@ -1,6 +1,7 @@
 " dotfiles
 "
-" Copyright 2019, 2020 Andrew Countryman <apcountryman@gmail.com>
+" Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+" contributors
 "
 " Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 " file except in compliance with the License. You may obtain a copy of the License at

--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -1,6 +1,7 @@
 " dotfiles
 "
-" Copyright 2019, 2020 Andrew Countryman <apcountryman@gmail.com>
+" Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+" contributors
 "
 " Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 " file except in compliance with the License. You may obtain a copy of the License at

--- a/git/hooks/install
+++ b/git/hooks/install
@@ -2,7 +2,8 @@
 
 # dotfiles
 #
-# Copyright 2019, 2020 Andrew Countryman <apcountryman@gmail.com>
+# Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+# contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 # file except in compliance with the License. You may obtain a copy of the License at

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -2,7 +2,8 @@
 
 # dotfiles
 #
-# Copyright 2019, 2020 Andrew Countryman <apcountryman@gmail.com>
+# Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+# contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 # file except in compliance with the License. You may obtain a copy of the License at

--- a/install
+++ b/install
@@ -2,7 +2,8 @@
 
 # dotfiles
 #
-# Copyright 2019, 2020 Andrew Countryman <apcountryman@gmail.com>
+# Copyright 2019-2021, Andrew Countryman <apcountryman@gmail.com> and the dotfiles
+# contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
 # file except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
Resolves #78.

Updating the copyright dates in a file when that specific file is
updated, and having each individual contributor add their own copy right
notice results in a non-standard copyright notice format which creates a
maintenance burden.
https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/
and
https://ben.balter.com/2015/06/03/copyright-notices-for-websites-and-open-source-projects/
discuss some of these maintenance burdens. Additionally, commits that
contain copyright notice updates in addition to other changes cannot be
reverted without messing up the copyright notices.

Standardizing the copyright notice text, and committing copyright date
updates independently of other changes eliminates these maintenance
burdens. 'Copyright [years], Andrew Countryman <apcountryman@gmail.com>
and the dotfiles contributors' will be the standard copyright notice
where '[years]' includes every year during which the project is actively
worked on.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
